### PR TITLE
feat(tribute-sdk): add `type` field in `WebhookSubscriptionPayload`

### DIFF
--- a/packages/tribute-sdk/src/types/webhooks.ts
+++ b/packages/tribute-sdk/src/types/webhooks.ts
@@ -15,6 +15,7 @@ export interface WebhookSubscriptionPayload {
   channel_id: number;
   channel_name: string;
   expires_at: string;
+  type: 'regular' | 'gift' | 'trial';
 }
 
 export interface WebhookEvent {


### PR DESCRIPTION
https://wiki.tribute.tg/for-content-creators/api-documentation/webhooks
<img width="746" height="239" alt="zen_NsXQpLTiMZ" src="https://github.com/user-attachments/assets/6aab576e-8e51-4e1f-ba2c-843389775a2d" />
